### PR TITLE
♻️ Use Fast Endpoints

### DIFF
--- a/.globalconfig
+++ b/.globalconfig
@@ -23,3 +23,9 @@ dotnet_diagnostic.IDE0061.severity = none
 csharp_style_namespace_declarations = file_scoped:error
 dotnet_diagnostic.IDE0160.severity = none
 dotnet_diagnostic.IDE0161.severity = error
+
+# Prefer static functions (C# 9+)
+csharp_prefer_static_anonymous_function = true
+dotnet_diagnostic.IDE0320.severity = error
+csharp_prefer_static_local_function = true
+dotnet_diagnostic.IDE0062.severity = error

--- a/.globalconfig
+++ b/.globalconfig
@@ -16,6 +16,7 @@ dotnet_diagnostic.IDE0007.severity = error
 dotnet_diagnostic.IDE0008.severity = none
 
 ## Allow expression and block bodies for local functions
+dotnet_diagnostic.IDE0022.severity = none
 dotnet_diagnostic.IDE0061.severity = none
 
 ## Use file-scoped namespaces

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,10 +4,10 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageVersion Include="FastEndpoints" Version="7.0.1" />
+		<PackageVersion Include="FastEndpoints.Swagger" Version="7.0.1" />
 		<PackageVersion Include="JetBrains.Annotations" Version="2025.2.2" />
-		<PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0-rc.1.25451.107" />
-		<PackageVersion Include="Scalar.AspNetCore" Version="2.8.7" />
-		<PackageVersion Include="Scalar.AspNetCore.Microsoft" Version="2.8.7" />
+		<PackageVersion Include="Scalar.AspNetCore" Version="2.8.8" />
+		<PackageVersion Include="Scalar.AspNetCore.Microsoft" Version="2.8.8" />
 	</ItemGroup>
 	<ItemGroup>
 		<GlobalPackageReference Include="SonarAnalyzer.CSharp" Version="10.15.0.120848" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,14 +1,15 @@
 <Project>
-	<PropertyGroup>
-		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-	</PropertyGroup>
-	<ItemGroup>
-		<PackageVersion Include="JetBrains.Annotations" Version="2025.2.2" />
-		<PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0-rc.1.25451.107" />
-		<PackageVersion Include="Scalar.AspNetCore" Version="2.8.7" />
-		<PackageVersion Include="Scalar.AspNetCore.Microsoft" Version="2.8.7" />
-	</ItemGroup>
-	<ItemGroup>
-		<GlobalPackageReference Include="SonarAnalyzer.CSharp" Version="10.15.0.120848" />
-	</ItemGroup>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="FastEndpoints" Version="7.0.1" />
+    <PackageVersion Include="JetBrains.Annotations" Version="2025.2.2" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0-rc.1.25451.107" />
+    <PackageVersion Include="Scalar.AspNetCore" Version="2.8.7" />
+    <PackageVersion Include="Scalar.AspNetCore.Microsoft" Version="2.8.7" />
+  </ItemGroup>
+  <ItemGroup>
+    <GlobalPackageReference Include="SonarAnalyzer.CSharp" Version="10.15.0.120848" />
+  </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,15 +1,15 @@
 <Project>
-  <PropertyGroup>
-    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-  </PropertyGroup>
-  <ItemGroup>
-    <PackageVersion Include="FastEndpoints" Version="7.0.1" />
-    <PackageVersion Include="JetBrains.Annotations" Version="2025.2.2" />
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0-rc.1.25451.107" />
-    <PackageVersion Include="Scalar.AspNetCore" Version="2.8.7" />
-    <PackageVersion Include="Scalar.AspNetCore.Microsoft" Version="2.8.7" />
-  </ItemGroup>
-  <ItemGroup>
-    <GlobalPackageReference Include="SonarAnalyzer.CSharp" Version="10.15.0.120848" />
-  </ItemGroup>
+	<PropertyGroup>
+		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+	</PropertyGroup>
+	<ItemGroup>
+		<PackageVersion Include="FastEndpoints" Version="7.0.1" />
+		<PackageVersion Include="JetBrains.Annotations" Version="2025.2.2" />
+		<PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0-rc.1.25451.107" />
+		<PackageVersion Include="Scalar.AspNetCore" Version="2.8.7" />
+		<PackageVersion Include="Scalar.AspNetCore.Microsoft" Version="2.8.7" />
+	</ItemGroup>
+	<ItemGroup>
+		<GlobalPackageReference Include="SonarAnalyzer.CSharp" Version="10.15.0.120848" />
+	</ItemGroup>
 </Project>

--- a/WebApp/HelloWorld/SayHello.cs
+++ b/WebApp/HelloWorld/SayHello.cs
@@ -1,0 +1,34 @@
+using System.Threading;
+using System.Threading.Tasks;
+using FastEndpoints;
+
+namespace Connorjs.BlazorTasks.WebApp.HelloWorld;
+
+internal sealed class SayHello : Endpoint<HelloRequest, HelloResponse>
+{
+	public override void Configure()
+	{
+		Get("/hi");
+		Get("/hi/{name}");
+		AllowAnonymous();
+	}
+
+	public override async Task HandleAsync(HelloRequest req, CancellationToken ct)
+	{
+		await Send.OkAsync(new HelloResponse() { Message = $"Hello, {req.Name ?? "world"}!" }, ct);
+	}
+}
+
+/// <summary>Request for the `SayHello` operation.</summary>
+public sealed record HelloRequest
+{
+	/// <summary>The name to greet.</summary>
+	public string? Name { get; init; }
+}
+
+/// <summary>Response for the `SayHello` operation.</summary>
+public sealed record HelloResponse
+{
+	/// <summary>The greeting message.</summary>
+	public required string Message { get; init; }
+}

--- a/WebApp/HelloWorld/SayHello.cs
+++ b/WebApp/HelloWorld/SayHello.cs
@@ -4,6 +4,9 @@ using FastEndpoints;
 
 namespace Connorjs.BlazorTasks.WebApp.HelloWorld;
 
+/// <remarks>
+/// Example “Hello, world!” operation.
+/// </remarks>
 internal sealed class SayHello : Endpoint<HelloRequest, HelloResponse>
 {
 	public override void Configure()

--- a/WebApp/HelloWorld/SayHello.cs
+++ b/WebApp/HelloWorld/SayHello.cs
@@ -1,13 +1,14 @@
 using System.Threading;
 using System.Threading.Tasks;
 using FastEndpoints;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
 
 namespace Connorjs.BlazorTasks.WebApp.HelloWorld;
 
-/// <remarks>
-/// Example “Hello, world!” operation.
-/// </remarks>
-internal sealed class SayHello : Endpoint<HelloRequest, HelloResponse>
+/// <summary>/hi</summary>
+/// <remarks>Example “Hello, world!” operation.</remarks>
+internal sealed class SayHello : Endpoint<HelloRequest, Results<Ok<HelloResponse>, ProblemDetails>>
 {
 	public override void Configure()
 	{
@@ -15,9 +16,19 @@ internal sealed class SayHello : Endpoint<HelloRequest, HelloResponse>
 		AllowAnonymous();
 	}
 
-	public override async Task HandleAsync(HelloRequest req, CancellationToken ct)
+	public override async Task<Results<Ok<HelloResponse>, ProblemDetails>> ExecuteAsync(
+		HelloRequest req,
+		CancellationToken ct
+	)
 	{
-		await Send.OkAsync(new HelloResponse() { Message = $"Hello, {req.Name ?? "world"}!" }, ct);
+		await Task.CompletedTask; // Example endpoint, but keep `Task` return.
+		if (req?.Name == "err")
+		{
+			AddError(r => r.Name, "Hello, error!");
+			return new ProblemDetails(ValidationFailures);
+		}
+
+		return TypedResults.Ok(new HelloResponse() { Message = $"Hello, {req?.Name ?? "world"}!" });
 	}
 }
 

--- a/WebApp/HelloWorld/SayHello.cs
+++ b/WebApp/HelloWorld/SayHello.cs
@@ -9,7 +9,6 @@ internal sealed class SayHello : Endpoint<HelloRequest, HelloResponse>
 	public override void Configure()
 	{
 		Get("/hi");
-		Get("/hi/{name}");
 		AllowAnonymous();
 	}
 
@@ -23,6 +22,7 @@ internal sealed class SayHello : Endpoint<HelloRequest, HelloResponse>
 public sealed record HelloRequest
 {
 	/// <summary>The name to greet.</summary>
+	[QueryParam]
 	public string? Name { get; init; }
 }
 

--- a/WebApp/Main/EndpointExtensions.cs
+++ b/WebApp/Main/EndpointExtensions.cs
@@ -1,0 +1,22 @@
+using FastEndpoints;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Connorjs.BlazorTasks.WebApp.Main;
+
+internal static class EndpointExtensions
+{
+	internal static T AddMyEndpoints<T>(this T builder)
+		where T : IHostApplicationBuilder
+	{
+		builder.Services.AddFastEndpoints().AddValidation();
+		return builder;
+	}
+
+	internal static WebApplication UseMyEndpoints(this WebApplication app)
+	{
+		app.UseFastEndpoints(o => o.Errors.UseProblemDetails());
+		return app;
+	}
+}

--- a/WebApp/Main/EndpointExtensions.cs
+++ b/WebApp/Main/EndpointExtensions.cs
@@ -16,7 +16,7 @@ internal static class EndpointExtensions
 
 	internal static WebApplication UseMyEndpoints(this WebApplication app)
 	{
-		app.UseFastEndpoints(o => o.Errors.UseProblemDetails());
+		app.UseFastEndpoints(static o => o.Errors.UseProblemDetails());
 		return app;
 	}
 }

--- a/WebApp/Main/EndpointExtensions.cs
+++ b/WebApp/Main/EndpointExtensions.cs
@@ -16,7 +16,11 @@ internal static class EndpointExtensions
 
 	internal static WebApplication UseMyEndpoints(this WebApplication app)
 	{
-		app.UseFastEndpoints(static o => o.Errors.UseProblemDetails());
+		app.UseFastEndpoints(static c =>
+		{
+			c.Errors.UseProblemDetails();
+			c.Endpoints.ShortNames = true;
+		});
 		return app;
 	}
 }

--- a/WebApp/Main/ExceptionHandlerExtensions.cs
+++ b/WebApp/Main/ExceptionHandlerExtensions.cs
@@ -1,33 +1,14 @@
-using System;
+using FastEndpoints;
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Diagnostics;
-using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 
 namespace Connorjs.BlazorTasks.WebApp.Main;
 
-internal static partial class ExceptionHandlerExtensions
+internal static class ExceptionHandlerExtensions
 {
 	internal static WebApplication UseMyExceptionHandler(this WebApplication app)
 	{
-		app.UseExceptionHandler(static errorApp =>
-			errorApp.Run(static async ctx =>
-			{
-				var logger = ctx.RequestServices.GetRequiredService<ILogger<Program>>();
-				logger.LogUnexpectedError(ctx.Features.Get<IExceptionHandlerFeature>()?.Error);
-
-				await Results
-					.Problem(
-						statusCode: StatusCodes.Status500InternalServerError,
-						title: "Unexpected error"
-					)
-					.ExecuteAsync(ctx);
-			})
-		);
+		// https://fast-endpoints.com/docs/exception-handler
+		app.UseDefaultExceptionHandler(logStructuredException: true, useGenericReason: true);
 		return app;
 	}
-
-	[LoggerMessage(EventId = 5000, Level = LogLevel.Error, Message = "Unhandled exception")]
-	public static partial void LogUnexpectedError(this ILogger logger, Exception? exception);
 }

--- a/WebApp/Main/ExceptionHandlerExtensions.cs
+++ b/WebApp/Main/ExceptionHandlerExtensions.cs
@@ -11,8 +11,8 @@ internal static partial class ExceptionHandlerExtensions
 {
 	internal static WebApplication UseMyExceptionHandler(this WebApplication app)
 	{
-		app.UseExceptionHandler(errorApp =>
-			errorApp.Run(async ctx =>
+		app.UseExceptionHandler(static errorApp =>
+			errorApp.Run(static async ctx =>
 			{
 				var logger = ctx.RequestServices.GetRequiredService<ILogger<Program>>();
 				logger.LogUnexpectedError(ctx.Features.Get<IExceptionHandlerFeature>()?.Error);

--- a/WebApp/Main/LoggingExtensions.cs
+++ b/WebApp/Main/LoggingExtensions.cs
@@ -15,7 +15,7 @@ internal static class LoggingExtensions
 		builder
 			.Logging.ClearProviders()
 			.AddConsole()
-			.Configure(o =>
+			.Configure(static o =>
 			{
 				o.ActivityTrackingOptions =
 					ActivityTrackingOptions.SpanId
@@ -24,7 +24,7 @@ internal static class LoggingExtensions
 					| ActivityTrackingOptions.Tags
 					| ActivityTrackingOptions.Baggage;
 			});
-		builder.Services.AddHttpLogging(o =>
+		builder.Services.AddHttpLogging(static o =>
 		{
 			o.LoggingFields =
 				HttpLoggingFields.Duration

--- a/WebApp/Main/OpenApiExtensions.cs
+++ b/WebApp/Main/OpenApiExtensions.cs
@@ -16,14 +16,14 @@ internal static class OpenApiExtensions
 	internal static T AddMyOpenApi<T>(this T builder)
 		where T : IHostApplicationBuilder
 	{
-		var openApiConfig = builder.Configuration.GetRequired<OpenApiConfig>("OpenApi");
+		var config = builder.Configuration.GetRequired<OpenApiConfig>("OpenApi");
 		builder.Services.AddOpenApi(
-			openApiConfig.DocumentName,
+			config.DocumentName,
 			o =>
 				o.AddDocumentTransformer(
 						(document, _, _) =>
 						{
-							document.Info = openApiConfig.Info;
+							document.Info = config.Info;
 							return Task.CompletedTask;
 						}
 					)
@@ -34,7 +34,6 @@ internal static class OpenApiExtensions
 
 	internal static WebApplication UseMyOpenApi(this WebApplication app)
 	{
-		// ReSharper disable once InvertIf -- I find this if more readable given same return
 		if (app.Environment.IsDevelopment())
 		{
 			var openApiConfig = app.Configuration.GetRequired<OpenApiConfig>("OpenApi");

--- a/WebApp/Main/OutputCacheExtensions.cs
+++ b/WebApp/Main/OutputCacheExtensions.cs
@@ -11,7 +11,11 @@ namespace Connorjs.BlazorTasks.WebApp.Main;
 internal static class OutputCacheExtensions
 {
 	[UsedImplicitly]
-	private sealed record OutputCacheConfig(bool Enabled, OutputCachePolicyConfig BasePolicy);
+	private sealed record OutputCacheConfig(
+		bool Enabled,
+		OutputCachePolicyConfig? BasePolicy = null,
+		IDictionary<string, OutputCachePolicyConfig>? Policies = null
+	);
 
 	[UsedImplicitly]
 	private sealed record OutputCachePolicyConfig(int ExpireSeconds);
@@ -24,11 +28,17 @@ internal static class OutputCacheExtensions
 		{
 			builder.Services.AddOutputCache(o =>
 			{
-				o.AddBasePolicy(FromConfig(config.BasePolicy));
-				// foreach (var policy in config.Policies)
-				// {
-				// 	o.AddPolicy(policy.Key, FromConfig(policy.Value));
-				// }
+				if (config.BasePolicy is not null)
+				{
+					o.AddBasePolicy(FromConfig(config.BasePolicy));
+				}
+				if (config.Policies is not null)
+				{
+					foreach (var policy in config.Policies)
+					{
+						o.AddPolicy(policy.Key, FromConfig(policy.Value));
+					}
+				}
 			});
 		}
 		return builder;

--- a/WebApp/Program.cs
+++ b/WebApp/Program.cs
@@ -1,34 +1,20 @@
-using System;
-using System.ComponentModel.DataAnnotations;
 using Connorjs.BlazorTasks.WebApp.Main;
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.DependencyInjection;
-using Scalar.AspNetCore;
 
-var builder = WebApplication.CreateBuilder(args);
-
-builder
-	.Services.AddOutputCache(o =>
-		o.AddBasePolicy(policy => policy.Expire(TimeSpan.FromMinutes(10)))
-	)
-	.AddValidation();
-
-var app = builder.AddMyLogging().AddMyOpenApi().Build();
-
-// Middleware chain
-// - Run exception handler first (early) in middleware pipeline to catch all exceptions
-app.UseMyExceptionHandler().UseMyLogging();
-
-// Endpoints intentionally kept in Program.cs (will switch to Fast Endpoints)
-const string tag = "HelloWorld";
-app.MapGet("/hi", ([FromQuery] [MinLength(3)] string? name) => Hello(name))
-	.Experimental()
-	.WithTags(tag);
-app.MapGet("/hi/{name}", Hello).Experimental().WithTags(tag);
-
-await app.UseMyOpenApi().RunAsync();
-return;
-
-static string Hello(string? name) => $"Hello, {name ?? "world"}!";
+await WebApplication
+	.CreateBuilder(args)
+	// -- Register services (order can matter) --
+	.AddMyLogging() // First (early) so others can use logging
+	.AddMyOutputCache()
+	.AddMyOpenApi()
+	.AddMyEndpoints() // Last (late) because wiring up the endpoints depends on everything else
+	// -- End services --
+	.Build()
+	// -- Middleware pipeline (order matters) --
+	.UseMyExceptionHandler() // Run exception handler first (early) to catch all exceptions
+	.UseMyLogging()
+	.UseMyOutputCache() // Before endpoints so [OutputCache] can attach
+	.UseMyEndpoints()
+	.UseMyOpenApi() // After endpoints
+	// -- End middleware pipeline --
+	.RunAsync();

--- a/WebApp/WebApp.csproj
+++ b/WebApp/WebApp.csproj
@@ -4,8 +4,8 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="FastEndpoints" />
+		<PackageReference Include="FastEndpoints.Swagger" />
 		<PackageReference Include="JetBrains.Annotations" />
-		<PackageReference Include="Microsoft.AspNetCore.OpenApi" />
 		<PackageReference Include="Scalar.AspNetCore" />
 		<PackageReference Include="Scalar.AspNetCore.Microsoft" />
 	</ItemGroup>

--- a/WebApp/WebApp.csproj
+++ b/WebApp/WebApp.csproj
@@ -3,6 +3,7 @@
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 	</PropertyGroup>
 	<ItemGroup>
+		<PackageReference Include="FastEndpoints" />
 		<PackageReference Include="JetBrains.Annotations" />
 		<PackageReference Include="Microsoft.AspNetCore.OpenApi" />
 		<PackageReference Include="Scalar.AspNetCore" />

--- a/WebApp/appsettings.json
+++ b/WebApp/appsettings.json
@@ -20,15 +20,9 @@
 	},
 	"OpenApi": {
 		"DocumentName": "blazor-tasks.openapi",
-		"Info": {
-			"Contact": {
-				"Name": "Connor Sullivan",
-				"Url": "https://github.com/connorjs",
-			},
-			"Description": "The Web API for my Blazor sample application.",
-			"Title": "Blazor Tasks API · @connorjs",
-			"Version": "2025-09-27",
-		},
+		"Title": "Blazor Tasks API · @connorjs",
+		"Description": "The Web API for my Blazor sample application.",
+		"Version": "2025-09-27",
 	},
 	"OutputCache": {
 		"Enabled": true,

--- a/WebApp/appsettings.json
+++ b/WebApp/appsettings.json
@@ -23,17 +23,18 @@
 		"Info": {
 			"Contact": {
 				"Name": "Connor Sullivan",
-				"Url": "https://github.com/connorjs"
+				"Url": "https://github.com/connorjs",
 			},
 			"Description": "The Web API for my Blazor sample application.",
 			"Title": "Blazor Tasks API · @connorjs",
 			"Version": "2025-09-27",
-		}
+		},
 	},
 	"OutputCache": {
 		"Enabled": true,
 		"BasePolicy": {
-			"ExpireSeconds": 60
-		}
-	}
+			"ExpireSeconds": 60,
+		},
+		"Policies": { },
+	},
 }

--- a/WebApp/appsettings.json
+++ b/WebApp/appsettings.json
@@ -30,4 +30,10 @@
 			"Version": "2025-09-27",
 		}
 	},
+	"OutputCache": {
+		"Enabled": true,
+		"BasePolicy": {
+			"ExpireSeconds": 60
+		}
+	}
 }

--- a/WebApp/appsettings.json
+++ b/WebApp/appsettings.json
@@ -3,6 +3,8 @@
 		"LogLevel": {
 			"Default": "Information",
 			"Microsoft": "Warning",
+			// Disable per https://fast-endpoints.com/docs/exception-handler
+			"Microsoft.AspNetCore.Diagnostics.ExceptionHandlerMiddleware": "None",
 			"Microsoft.AspNetCore.HttpLogging": "Information",
 			"Microsoft.Hosting.Lifetime": "Information",
 		},


### PR DESCRIPTION
Switches to using Fast Endpoints.

- Adds `FastEndpoints`
- Moves example minimal APIs to `SayHello` endpoint
- Cleans up `Program.cs` (move everything to extension methods)
- Adds config-driven output cache
- Removes .NET built-in Open API code in favor of `NSwag` (used by `FastEndpoints`)
- Updates Scalar API documentation config